### PR TITLE
PUB-4335: expose attachment metadata to S3

### DIFF
--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -159,7 +159,9 @@ class S3_Uploads_Stream_Wrapper
 					try {
 						$p = $this->params;
 						$p['Body'] = '';
+						$params['post_id'] = attachment_url_to_postid($params['Key']);
 						$p = apply_filters( 's3_uploads_putObject_params', $p );
+						unset($p['post_id']);
 						$this->getClient()->putObject($p);
 					} catch (Exception $e) {
 						return $this->triggerError($e->getMessage());
@@ -208,6 +210,10 @@ class S3_Uploads_Stream_Wrapper
 			}
 		}
 
+		// Post ID (e.g., for an attachment) on the request which originated the file, if applicable
+		$filename = end(explode('/', $params['Key']));
+		$params_with_post_id = array_merge($params, array('post_id' => attachment_url_to_postid($filename)));
+
 		/**
 		 * Filter the parameters passed to S3
 		 * Theses are the parameters passed to S3Client::putObject()
@@ -215,7 +221,8 @@ class S3_Uploads_Stream_Wrapper
 		 *
 		 * @param array $params S3Client::putObject parameters.
 		 */
-		$params = apply_filters( 's3_uploads_putObject_params',  $params );
+		$params = apply_filters( 's3_uploads_putObject_params',  $params_with_post_id);
+		unset($params['post_id']);
 
 		$this->clearCacheKey("s3://{$params['Bucket']}/{$params['Key']}");
 		return $this->boolCall(function () use ($params) {

--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -159,7 +159,8 @@ class S3_Uploads_Stream_Wrapper
 					try {
 						$p = $this->params;
 						$p['Body'] = '';
-						$params['post_id'] = attachment_url_to_postid($params['Key']);
+						$filename = basename($params['Key']);
+						$params['post_id'] = attachment_url_to_postid($filename);
 						$p = apply_filters( 's3_uploads_putObject_params', $p );
 						unset($p['post_id']);
 						$this->getClient()->putObject($p);
@@ -211,7 +212,7 @@ class S3_Uploads_Stream_Wrapper
 		}
 
 		// Post ID (e.g., for an attachment) on the request which originated the file, if applicable
-		$filename = end(explode('/', $params['Key']));
+		$filename = basename($params['Key']);
 		$params_with_post_id = array_merge($params, array('post_id' => attachment_url_to_postid($filename)));
 
 		/**

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -538,17 +538,17 @@ class S3_Uploads {
 		$commands = [];
 		foreach ( $locations as $location ) {
 			try {
-				$headers = $s3 -> headObject([
+				$headers = $s3 -> headObject( [
 					'Bucket' => $location['bucket'],
 					'Key' => $location['key'],
-				]);
+				] );
 
 				$new_meta = $values;
-				if (array_key_exists('Metadata', $headers) && is_array($headers['Metadata'])){
-					$new_meta = array_merge($headers['Metadata'], $values);
+				if ( array_key_exists( 'Metadata', $headers) && is_array( $headers['Metadata'] ) ) {
+					$new_meta = array_merge( $headers['Metadata'], $values );
 				}
 
-				$s3->copyObject([
+				$s3->copyObject( [
 					'Bucket' => $location['bucket'],
 					'Key' => $location['key'],
 					'CopySource' => $location['bucket'] . "/" . $location['key'],


### PR DESCRIPTION
Adds a method to update the metadata on all the files associated with an attachment ID (by retrieving the metadata, calling `array_merge`, and putting it back again). Also, looks up the `post_id` of an attachment at write time, and if found, injects it as a parameter into the `$params` to the `s3_upload_putObject_params` filter.

I unset the `post_id` after passing it to the filter so it isn't passed to S3. I would have passed it as a separate argument (so the signature of the filter would be `f($params, $post_id)`, but that caused some kind of WP core error which I couldn't fix.